### PR TITLE
Add `FastMoney`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,8 @@
         cheshire/cheshire {:mvn/version "5.13.0"}} ; required by hato for JSON parsing
  
  :aliases
- {:dev {:extra-paths ["dev"]}
+ {:dev {:extra-paths ["dev"]
+        :extra-deps {criterium/criterium {:mvn/version "0.4.6"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]

--- a/dev/arithmetic_operations_simulation.clj
+++ b/dev/arithmetic_operations_simulation.clj
@@ -2,70 +2,81 @@
   (:require [criterium.core :as criterium]
             [dinero.core :as core]))
 
-(defn money-simulation
-  [money]
-  (-> money
-      (core/add (core/money-of 1234567.3444 :eur))
-      (core/subtract (core/money-of 232323 :eur))
-      (core/multiply 3.4)
-      (core/divide 5.456)))
+(def money-simulation
+  (let [addend (core/money-of 1234567.3444 :eur)
+        subtrahend (core/money-of 232323 :eur)]
+    (fn [money]
+      (-> money
+          (core/add addend)
+          (core/subtract subtrahend)
+          (core/multiply 3.4)
+          (core/divide 5.456)))))
 
 (comment
   (criterium/bench
       (reduce (fn [acc _] (money-simulation acc)) (core/money-of 0 :eur) (range 1000000))))
 ;; Evaluation count : 60 in 60 samples of 1 calls.
-;;              Execution time mean : 2,394855 sec
-;;     Execution time std-deviation : 79,951502 ms
-;;    Execution time lower quantile : 2,313923 sec ( 2,5%)
-;;    Execution time upper quantile : 2,525123 sec (97,5%)
-;;                    Overhead used : 6,546638 ns
-;;
+;;              Execution time mean : 2,324543 sec
+;;     Execution time std-deviation : 10,797871 ms
+;;    Execution time lower quantile : 2,311543 sec ( 2,5%)
+;;    Execution time upper quantile : 2,351981 sec (97,5%)
+;;                    Overhead used : 6,521613 ns
+
+;; Found 4 outliers in 60 samples (6,6667 %)
+;; 	low-severe	 4 (6,6667 %)
+;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
+
 ;; => {:amount 1657407.9625291828793774319066147859922178988326848249027237354085603112840466926070038910505836575875486381322957198443579766536964980544747081712062256809338521400778210116731517509727626459143968871595330739299610894941634241245136186770428015564202334630350194M, :currency :eur}
 
-(defn rounded-money-simulation
-  [money]
-  (-> money
-      (core/add (core/rounded-money-of 1234567.3444 :eur 2 :half-even))
-      (core/subtract (core/rounded-money-of 232323 :eur 2 :half-even))
-      (core/multiply 3.4)
-      (core/divide 5.456)))
+(def rounded-money-simulation
+  (let [addend (core/rounded-money-of 1234567.3444 :eur 2 :half-even)
+        subtrahend (core/rounded-money-of 232323 :eur 2 :half-even)]
+    (fn [money]
+      (-> money
+          (core/add addend)
+          (core/subtract subtrahend)
+          (core/multiply 3.4)
+          (core/divide 5.456)))))
 
 (comment
  (criterium/bench
      (reduce (fn [acc _] (rounded-money-simulation acc)) (core/rounded-money-of 0 :eur 2 :half-even) (range 1000000))))
 ;; Evaluation count : 60 in 60 samples of 1 calls.
-;;              Execution time mean : 3,843440 sec
-;;     Execution time std-deviation : 6,455752 ms
-;;    Execution time lower quantile : 3,832537 sec ( 2,5%)
-;;    Execution time upper quantile : 3,854636 sec (97,5%)
-;;                    Overhead used : 6,546638 ns
-;; Found 1 outliers in 60 samples (1,6667 %)
+;;              Execution time mean : 3,222852 sec
+;;     Execution time std-deviation : 10,467930 ms
+;;    Execution time lower quantile : 3,214198 sec ( 2,5%)
+;;    Execution time upper quantile : 3,232669 sec (97,5%)
+;;                    Overhead used : 6,521613 ns
+
+;; Found 2 outliers in 60 samples (3,3333 %)
 ;; 	low-severe	 1 (1,6667 %)
+;; 	low-mild	 1 (1,6667 %)
 ;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
-;;
+
 ;; => {:amount 1657407.95M, :currency :eur, :scale 2, :rounding-mode :half-even}
 
-(defn fast-money-simulation
-  [money]
-  (-> money
-      (core/add (core/fast-money-of 1234567.3444 :eur))
-      (core/subtract (core/fast-money-of 232323 :eur))
-      (core/multiply 3.4)
-      (core/divide 5.456)))
+(def fast-money-simulation
+  (let [addend (core/fast-money-of 1234567.3444 :eur)
+        subtrahend (core/fast-money-of 232323 :eur)]
+    (fn [money]
+      (-> money
+          (core/add addend)
+          (core/subtract subtrahend)
+          (core/multiply 3.4)
+          (core/divide 5.456)))))
 
 (comment
   (criterium/bench
       (reduce (fn [acc _] (fast-money-simulation acc)) (core/fast-money-of 0 :eur) (range 1000000))))
 ;; Evaluation count : 60 in 60 samples of 1 calls.
-;;              Execution time mean : 2,085946 sec
-;;     Execution time std-deviation : 121,642628 ms
-;;    Execution time lower quantile : 1,966039 sec ( 2,5%)
-;;    Execution time upper quantile : 2,334722 sec (97,5%)
-;;                    Overhead used : 6,546638 ns
+;;              Execution time mean : 1,672895 sec
+;;     Execution time std-deviation : 7,729889 ms
+;;    Execution time lower quantile : 1,662126 sec ( 2,5%)
+;;    Execution time upper quantile : 1,689020 sec (97,5%)
+;;                    Overhead used : 6,521613 ns
 
-;; Found 8 outliers in 60 samples (13,3333 %)
-;; 	low-severe	 7 (11,6667 %)
-;; 	low-mild	 1 (1,6667 %)
-;;  Variance from outliers : 43,4493 % Variance is moderately inflated by outliers
-;;
+;; Found 2 outliers in 60 samples (3,3333 %)
+;; 	low-severe	 2 (3,3333 %)
+;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
+
 ;; => {:amount 1657407.96252, :currency :eur}

--- a/dev/arithmetic_operations_simulation.clj
+++ b/dev/arithmetic_operations_simulation.clj
@@ -1,5 +1,6 @@
 (ns dev.arithmetic-operations-simulation
-  (:require [dinero.core :as core]))
+  (:require [criterium.core :as criterium]
+            [dinero.core :as core]))
 
 (defn money-simulation
   [money]
@@ -9,9 +10,16 @@
       (core/multiply 3.4)
       (core/divide 5.456)))
 
-(time
- (reduce (fn [acc _] (money-simulation acc)) (core/money-of 0 :eur) (range 1000000)))
-;; => "Elapsed time: 3795.038377 msecs"
+(comment
+  (criterium/bench
+      (reduce (fn [acc _] (money-simulation acc)) (core/money-of 0 :eur) (range 1000000))))
+;; Evaluation count : 60 in 60 samples of 1 calls.
+;;              Execution time mean : 2,394855 sec
+;;     Execution time std-deviation : 79,951502 ms
+;;    Execution time lower quantile : 2,313923 sec ( 2,5%)
+;;    Execution time upper quantile : 2,525123 sec (97,5%)
+;;                    Overhead used : 6,546638 ns
+;;
 ;; => {:amount 1657407.9625291828793774319066147859922178988326848249027237354085603112840466926070038910505836575875486381322957198443579766536964980544747081712062256809338521400778210116731517509727626459143968871595330739299610894941634241245136186770428015564202334630350194M, :currency :eur}
 
 (defn rounded-money-simulation
@@ -22,9 +30,19 @@
       (core/multiply 3.4)
       (core/divide 5.456)))
 
-(time
- (reduce (fn [acc _] (rounded-money-simulation acc)) (core/rounded-money-of 0 :eur 2 :half-even) (range 1000000)))
-;; => "Elapsed time: 7031.994195 msecs"
+(comment
+ (criterium/bench
+     (reduce (fn [acc _] (rounded-money-simulation acc)) (core/rounded-money-of 0 :eur 2 :half-even) (range 1000000))))
+;; Evaluation count : 60 in 60 samples of 1 calls.
+;;              Execution time mean : 3,843440 sec
+;;     Execution time std-deviation : 6,455752 ms
+;;    Execution time lower quantile : 3,832537 sec ( 2,5%)
+;;    Execution time upper quantile : 3,854636 sec (97,5%)
+;;                    Overhead used : 6,546638 ns
+;; Found 1 outliers in 60 samples (1,6667 %)
+;; 	low-severe	 1 (1,6667 %)
+;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
+;;
 ;; => {:amount 1657407.95M, :currency :eur, :scale 2, :rounding-mode :half-even}
 
 (defn fast-money-simulation
@@ -35,7 +53,19 @@
       (core/multiply 3.4)
       (core/divide 5.456)))
 
-(time
- (reduce (fn [acc _] (fast-money-simulation acc)) (core/fast-money-of 0 :eur) (range 1000000)))
-;; => "Elapsed time: 3557.049248 msecs"
+(comment
+  (criterium/bench
+      (reduce (fn [acc _] (fast-money-simulation acc)) (core/fast-money-of 0 :eur) (range 1000000))))
+;; Evaluation count : 60 in 60 samples of 1 calls.
+;;              Execution time mean : 2,085946 sec
+;;     Execution time std-deviation : 121,642628 ms
+;;    Execution time lower quantile : 1,966039 sec ( 2,5%)
+;;    Execution time upper quantile : 2,334722 sec (97,5%)
+;;                    Overhead used : 6,546638 ns
+
+;; Found 8 outliers in 60 samples (13,3333 %)
+;; 	low-severe	 7 (11,6667 %)
+;; 	low-mild	 1 (1,6667 %)
+;;  Variance from outliers : 43,4493 % Variance is moderately inflated by outliers
+;;
 ;; => {:amount 1657407.96252, :currency :eur}

--- a/dev/arithmetic_operations_simulation.clj
+++ b/dev/arithmetic_operations_simulation.clj
@@ -2,41 +2,44 @@
   (:require [criterium.core :as criterium]
             [dinero.core :as core]))
 
-(def money-simulation
-  (let [addend (core/money-of 1234567.3444 :eur)
-        subtrahend (core/money-of 232323 :eur)]
-    (fn [money]
-      (-> money
-          (core/add addend)
-          (core/subtract subtrahend)
-          (core/multiply 3.4)
-          (core/divide 5.456)))))
+(let [addend (core/money-of 1234567.3444 :eur)
+      subtrahend (core/money-of 232323 :eur)]
+  (defn money-simulation
+    [money]
+    (-> money
+        (core/add addend)
+        (core/subtract subtrahend)
+        (core/multiply 3.4)
+        (core/divide 5.456))))
 
 (comment
   (criterium/bench
       (reduce (fn [acc _] (money-simulation acc)) (core/money-of 0 :eur) (range 1000000))))
 ;; Evaluation count : 60 in 60 samples of 1 calls.
-;;              Execution time mean : 2,324543 sec
-;;     Execution time std-deviation : 10,797871 ms
-;;    Execution time lower quantile : 2,311543 sec ( 2,5%)
-;;    Execution time upper quantile : 2,351981 sec (97,5%)
-;;                    Overhead used : 6,521613 ns
-
-;; Found 4 outliers in 60 samples (6,6667 %)
-;; 	low-severe	 4 (6,6667 %)
+;;              Execution time mean : 2,184454 sec
+;;     Execution time std-deviation : 10,434630 ms
+;;    Execution time lower quantile : 2,158174 sec ( 2,5%)
+;;    Execution time upper quantile : 2,203948 sec (97,5%)
+;;                    Overhead used : 6,970274 ns
+;;
+;; Found 9 outliers in 60 samples (15,0000 %)
+;; 	low-severe	 3 (5,0000 %)
+;; 	low-mild	 2 (3,3333 %)
+;; 	high-mild	 3 (5,0000 %)
+;; 	high-severe	 1 (1,6667 %)
 ;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
 
 ;; => {:amount 1657407.9625291828793774319066147859922178988326848249027237354085603112840466926070038910505836575875486381322957198443579766536964980544747081712062256809338521400778210116731517509727626459143968871595330739299610894941634241245136186770428015564202334630350194M, :currency :eur}
 
-(def rounded-money-simulation
-  (let [addend (core/rounded-money-of 1234567.3444 :eur 2 :half-even)
-        subtrahend (core/rounded-money-of 232323 :eur 2 :half-even)]
-    (fn [money]
-      (-> money
-          (core/add addend)
-          (core/subtract subtrahend)
-          (core/multiply 3.4)
-          (core/divide 5.456)))))
+(let [addend (core/rounded-money-of 1234567.3444 :eur 2 :half-even)
+      subtrahend (core/rounded-money-of 232323 :eur 2 :half-even)]
+  (defn rounded-money-simulation
+    [money]
+    (-> money
+        (core/add addend)
+        (core/subtract subtrahend)
+        (core/multiply 3.4)
+        (core/divide 5.456))))
 
 (comment
  (criterium/bench
@@ -55,28 +58,29 @@
 
 ;; => {:amount 1657407.95M, :currency :eur, :scale 2, :rounding-mode :half-even}
 
-(def fast-money-simulation
-  (let [addend (core/fast-money-of 1234567.3444 :eur)
-        subtrahend (core/fast-money-of 232323 :eur)]
-    (fn [money]
-      (-> money
-          (core/add addend)
-          (core/subtract subtrahend)
-          (core/multiply 3.4)
-          (core/divide 5.456)))))
+(let [addend (core/fast-money-of 1234567.3444 :eur)
+      subtrahend (core/fast-money-of 232323 :eur)]
+  (defn fast-money-simulation
+    [money]
+    (-> money
+        (core/add addend)
+        (core/subtract subtrahend)
+        (core/multiply 3.4)
+        (core/divide 5.456))))
 
 (comment
   (criterium/bench
       (reduce (fn [acc _] (fast-money-simulation acc)) (core/fast-money-of 0 :eur) (range 1000000))))
 ;; Evaluation count : 60 in 60 samples of 1 calls.
-;;              Execution time mean : 1,672895 sec
-;;     Execution time std-deviation : 7,729889 ms
-;;    Execution time lower quantile : 1,662126 sec ( 2,5%)
-;;    Execution time upper quantile : 1,689020 sec (97,5%)
-;;                    Overhead used : 6,521613 ns
-
-;; Found 2 outliers in 60 samples (3,3333 %)
-;; 	low-severe	 2 (3,3333 %)
-;;  Variance from outliers : 1,6389 % Variance is slightly inflated by outliers
+;;              Execution time mean : 1,338023 sec
+;;     Execution time std-deviation : 24,957735 ms
+;;    Execution time lower quantile : 1,314668 sec ( 2,5%)
+;;    Execution time upper quantile : 1,395095 sec (97,5%)
+;;                    Overhead used : 6,970274 ns
+;;
+;; Found 7 outliers in 60 samples (11,6667 %)
+;; 	low-severe	 5 (8,3333 %)
+;; 	low-mild	 2 (3,3333 %)
+;;  Variance from outliers : 7,8135 % Variance is slightly inflated by outliers
 
 ;; => {:amount 1657407.96252, :currency :eur}

--- a/dev/arithmetic_operations_simulation.clj
+++ b/dev/arithmetic_operations_simulation.clj
@@ -26,3 +26,16 @@
  (reduce (fn [acc _] (rounded-money-simulation acc)) (core/rounded-money-of 0 :eur 2 :half-even) (range 1000000)))
 ;; => "Elapsed time: 7031.994195 msecs"
 ;; => {:amount 1657407.95M, :currency :eur, :scale 2, :rounding-mode :half-even}
+
+(defn fast-money-simulation
+  [money]
+  (-> money
+      (core/add (core/fast-money-of 1234567.3444 :eur))
+      (core/subtract (core/fast-money-of 232323 :eur))
+      (core/multiply 3.4)
+      (core/divide 5.456)))
+
+(time
+ (reduce (fn [acc _] (fast-money-simulation acc)) (core/fast-money-of 0 :eur) (range 1000000)))
+;; => "Elapsed time: 3557.049248 msecs"
+;; => {:amount 1657407.96252, :currency :eur}

--- a/src/dinero/conversion/core.clj
+++ b/src/dinero/conversion/core.clj
@@ -7,15 +7,14 @@
 (defn convert-using-exchange-rate
   "Converts the given monetary amount to the term currency using the given exchange rate."
   [money term-currency exchange-rate]
-  (if (core/money? money)
-    (let [amount (core/get-amount money)
-          term-amount (* amount exchange-rate)]
-      (core/money-of term-amount term-currency))
-    (let [amount (core/get-amount money)
-          decimal-places (core/get-scale money)
-          rounding-mode (core/get-rounding-mode money)
-          term-amount (* amount exchange-rate)]
-      (core/rounded-money-of term-amount term-currency decimal-places rounding-mode))))
+  (let [amount (core/get-amount money)
+        term-amount (* amount exchange-rate)]
+    (cond
+      (core/money? money) (core/money-of term-amount term-currency)
+      (core/fast-money? money) (core/fast-money-of term-amount term-currency)
+      :else (let [decimal-places (core/get-scale money)
+                  rounding-mode (core/get-rounding-mode money)]
+              (core/rounded-money-of term-amount term-currency decimal-places rounding-mode)))))
 
 (defn convert-using-db
   "Converts the given monetary amount to the term currency using the given database and schema information."

--- a/src/dinero/core.clj
+++ b/src/dinero/core.clj
@@ -366,17 +366,15 @@
 (defmethod multiply FastMoney
   [money factor]
   (let [amount-as-long (:amount money)
-        factor-scaled (to-fast-money-long factor)
-        product-scaled (try (* amount-as-long factor-scaled)
-                            (catch ArithmeticException e
-                              (throw (ex-info "`FastMoney` multiplication failed: amount exceeds precision of `FastMoney` (`long`-based). Consider using `Money` (`BigDecimal`-based) instead."
-                                              {:money money
-                                               :factor factor
-                                               :error (ex-message e)}))))
-        product (long (from-fast-money product-scaled fast-money-max-scale))
+        product-as-long (try (* amount-as-long factor)
+                             (catch ArithmeticException e
+                               (throw (ex-info "`FastMoney` multiplication failed: amount exceeds precision of `FastMoney` (`long`-based). Consider using `Money` (`BigDecimal`-based) instead."
+                                               {:money money
+                                                :factor factor
+                                                :error (ex-message e)}))))
         currency (get-currency money)]
-    ;; use `FastMoney` constructor directly instead of `fast-money-of` to improve performance
-    (FastMoney. product currency fast-money-max-scale)))
+    ;; use `FastMoney` constructor because we are working with the internal representation (`long` amounts) directly
+    (FastMoney. product-as-long currency fast-money-max-scale)))
 
 (defmethod divide Money
   [money divisor]

--- a/src/dinero/core.clj
+++ b/src/dinero/core.clj
@@ -141,17 +141,17 @@
     (throw (ex-info "Currencies do not match" {:currencies (map get-currency moneis)}))))
 
 (defn- same-scale?
-  "Returns true if all the given rounded monetary amounts have the same scale."
-  [& rounded-moneis]
-  (when (some nil? rounded-moneis)
+  "Returns true if all the given monetary amounts have the same scale."
+  [& moneis]
+  (when (some nil? moneis)
     (throw (ex-info "Scale must be non-nil" {})))
-  (apply = (map get-scale rounded-moneis)))
+  (apply = (map get-scale moneis)))
 
 (defn- assert-same-scale
-  "Asserts that all the given rounded monetary amounts have the same scale."
-  [& rounded-moneis]
-  (when-not (apply same-scale? rounded-moneis)
-    (throw (ex-info "Scales do not match" {:scales (map get-scale rounded-moneis)}))))
+  "Asserts that all the given monetary amounts have the same scale."
+  [& moneis]
+  (when-not (apply same-scale? moneis)
+    (throw (ex-info "Scales do not match" {:scales (map get-scale moneis)}))))
 
 (defn- same-rounding-mode?
   "Returns true if all the given rounded monetary amounts have the same rounding mode."
@@ -382,11 +382,11 @@
   [& moneis]
   (apply assert-same-currency-scale-and-rounding-mode moneis)
   (let [amounts (map get-amount moneis)
-          max-amount (apply max amounts)
-          currency (get-currency (first moneis))
-          scale (get-scale (first moneis))
-          rounding-mode (get-rounding-mode (first moneis))]
-      (rounded-money-of max-amount currency scale rounding-mode)))
+        max-amount (apply max amounts)
+        currency (get-currency (first moneis))
+        scale (get-scale (first moneis))
+        rounding-mode (get-rounding-mode (first moneis))]
+    (rounded-money-of max-amount currency scale rounding-mode)))
 
 (defmethod money-min Money
   [& moneis]

--- a/src/dinero/core.clj
+++ b/src/dinero/core.clj
@@ -17,11 +17,11 @@
 
 ;;; Monetary amounts
 
-(defrecord Money [amount currency])
+(defrecord Money [^BigDecimal amount currency])
 
-(defrecord RoundedMoney [amount currency scale rounding-mode])
+(defrecord RoundedMoney [^BigDecimal amount currency scale rounding-mode])
 
-(defrecord FastMoney [amount currency scale])
+(defrecord FastMoney [^long amount currency scale])
 
 (defn- to-fast-money-long
   "Converts the given amount to the `long`-based internal representation of `FastMoney`."

--- a/src/dinero/core.clj
+++ b/src/dinero/core.clj
@@ -380,7 +380,7 @@
         rounding-mode (utils/keyword->rounding-mode (or *default-rounding-mode* :half-even))
         quotient (BigDecimal/.divide ^BigDecimal amount (bigdec divisor) scale ^RoundingMode rounding-mode)
         currency (get-currency money)]
-    (money-of (BigDecimal/.stripTrailingZeros quotient) currency)))
+    (money-of quotient currency)))
 
 (defmethod divide RoundedMoney
   [money divisor]
@@ -390,12 +390,21 @@
         rounding-mode (get-rounding-mode money)
         rounding-mode-object (utils/keyword->rounding-mode rounding-mode)
         quotient (BigDecimal/.divide ^BigDecimal amount (bigdec divisor) ^int scale ^RoundingMode rounding-mode-object)]
-    (rounded-money-of (BigDecimal/.stripTrailingZeros quotient) currency scale rounding-mode)))
+    (rounded-money-of quotient currency scale rounding-mode)))
 
-;; TODO: Implement `divide` for `FastMoney`
+(defn- round-double
+  "Rounds the given double value to the given precision."
+  [value precission]
+  (let [factor (Math/pow 10 precission)]
+    (/ (Math/round (* value factor)) factor)))
+
 (defmethod divide FastMoney
   [money divisor]
-  :not-implemented)
+  (let [amount (get-amount money)
+        quotient (/ amount divisor)
+        quotient-rounded (round-double quotient fast-money-max-scale)
+        currency (get-currency money)]
+    (fast-money-of quotient-rounded currency)))
 
 (defmethod negate Money
   [money]

--- a/src/dinero/rounding.clj
+++ b/src/dinero/rounding.clj
@@ -10,29 +10,31 @@
   "Rounds the given monetary amount"
   ([money]
    (let [minor-units (currency/get-minor-units (core/get-currency money))
-         decimal-places (or minor-units (BigDecimal/.scale (core/get-amount money)))
+         decimal-places (or minor-units (BigDecimal/.scale (bigdec (core/get-amount money))))
          rounding-mode (or core/*default-rounding-mode* :half-even)]
      (round money decimal-places rounding-mode)))
   ([money rounding-fn]
    (rounding-fn money))
   ([money decimal-places rounding-mode]
-   (let [amount (core/get-amount money)
+   (let [amount (bigdec (core/get-amount money))
          currency (core/get-currency money)
          rounding-mode-object (utils/keyword->rounding-mode rounding-mode)
          rounded (BigDecimal/.setScale ^BigDecimal amount ^int decimal-places ^RoundingMode rounding-mode-object)]
-     (if (core/money? money)
-       (core/money-of rounded currency)
-       (core/rounded-money-of rounded currency decimal-places rounding-mode)))))
+     (cond
+       (core/money? money) (core/money-of rounded currency)
+       (core/fast-money? money) (core/fast-money-of rounded currency)
+       :else (core/rounded-money-of rounded currency decimal-places rounding-mode)))))
 
 (defn chf-rounding-fn
   "Creates a rounding function for Swiss Francs."
   [money]
-  (let [amount (core/get-amount money)
+  (let [amount (bigdec (core/get-amount money))
         currency (core/get-currency money)
         scale 0
         rounded (BigDecimal/.multiply
                  (BigDecimal/.divide ^BigDecimal amount (bigdec 0.05) scale RoundingMode/HALF_UP)
                  (bigdec 0.05))]
-    (if (core/money? money)
-      (core/money-of rounded currency)
-      (core/rounded-money-of rounded currency 2 :half-up))))
+    (cond
+      (core/money? money) (core/money-of rounded currency)
+      (core/fast-money? money) (core/fast-money-of rounded currency)
+      :else (core/rounded-money-of rounded currency 2 :half-up))))

--- a/src/dinero/rounding.clj
+++ b/src/dinero/rounding.clj
@@ -10,13 +10,13 @@
   "Rounds the given monetary amount"
   ([money]
    (let [minor-units (currency/get-minor-units (core/get-currency money))
-         decimal-places (or minor-units (BigDecimal/.scale (bigdec (core/get-amount money))))
+         decimal-places (or minor-units (BigDecimal/.scale (core/get-amount money)))
          rounding-mode (or core/*default-rounding-mode* :half-even)]
      (round money decimal-places rounding-mode)))
   ([money rounding-fn]
    (rounding-fn money))
   ([money decimal-places rounding-mode]
-   (let [amount (bigdec (core/get-amount money))
+   (let [amount (core/get-amount money)
          currency (core/get-currency money)
          rounding-mode-object (utils/keyword->rounding-mode rounding-mode)
          rounded (BigDecimal/.setScale ^BigDecimal amount ^int decimal-places ^RoundingMode rounding-mode-object)]
@@ -28,7 +28,7 @@
 (defn chf-rounding-fn
   "Creates a rounding function for Swiss Francs."
   [money]
-  (let [amount (bigdec (core/get-amount money))
+  (let [amount (core/get-amount money)
         currency (core/get-currency money)
         scale 0
         rounded (BigDecimal/.multiply

--- a/test/dinero/conversion/core_test.clj
+++ b/test/dinero/conversion/core_test.clj
@@ -15,12 +15,18 @@
           exchange-rate 0.80
           converted (sut/convert-using-exchange-rate money term-currency exchange-rate)]
       (t/is (= (core/money-of 0.80 :gbp) converted))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [money (core/rounded-money-of 1M :eur)
           term-currency :gbp
           exchange-rate 0.80
           converted (sut/convert-using-exchange-rate money term-currency exchange-rate)]
-      (t/is (= (core/rounded-money-of 0.80 :gbp) converted)))))
+      (t/is (= (core/rounded-money-of 0.80 :gbp) converted))))
+  (t/testing "Fast Money"
+    (let [money (core/fast-money-of 1M :eur)
+          term-currency :gbp
+          exchange-rate 0.80
+          converted (sut/convert-using-exchange-rate money term-currency exchange-rate)]
+      (t/is (= (core/fast-money-of 0.80 :gbp) converted)))))
 
 (t/use-fixtures :once h/db-fixture)
 

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -149,7 +149,7 @@
       (t/is (= (sut/money-of 3 :eur) (sut/add m1 m2)))
       (t/is (= (sut/money-of 6 :eur) (sut/add m1 m2 m3)))
       (t/is (thrown? ExceptionInfo (sut/add (sut/money-of 1 :eur) (sut/money-of 1 :gbp))))))
-  (t/testing "Rounded money")
+  (t/testing "Rounded Money")
   (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
         m2 (sut/rounded-money-of 1.555 :eur 2 :down)
         m3 (sut/rounded-money-of 1.555 :eur 2 :up)]
@@ -158,7 +158,18 @@
   (t/testing "Mix money and rounded money"
     (let [m1 (sut/money-of 1 :eur)
           m2 (sut/rounded-money-of 1 :eur)]
-      (t/is (= (sut/money-of 2 :eur) (sut/add m1 m2))))))
+      (t/is (= (sut/money-of 2 :eur) (sut/add m1 m2)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of 2 :eur)
+          m3 (sut/fast-money-of 3 :eur)]
+      (t/is (= (sut/fast-money-of 3 :eur) (sut/add m1 m2)))
+      (t/is (= (sut/fast-money-of 6 :eur) (sut/add m1 m2 m3)))
+      ;; long overflow
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of Long/MAX_VALUE :eur) (sut/fast-money-of 1 :eur))))
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of Long/MIN_VALUE :eur) (sut/fast-money-of -1 :eur))))
+      ;; different currencies
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))))
 
 (t/deftest subtract
   (t/testing "Money"
@@ -168,7 +179,7 @@
       (t/is (= (sut/money-of 1 :eur) (sut/subtract m1 m2)))
       (t/is (= (sut/money-of 0 :eur) (sut/subtract m1 m2 m3)))
       (t/is (thrown? ExceptionInfo (sut/subtract (sut/money-of 1 :eur) (sut/money-of 1 :gbp))))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of 1.555 :eur 2 :down)
           m3 (sut/rounded-money-of 1.555 :eur 2 :up)]
@@ -184,7 +195,7 @@
     (let [money (sut/money-of 1 :eur)
           factor 2]
       (t/is (= (sut/money-of 2 :eur) (sut/multiply money factor)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [money (sut/rounded-money-of 1.555 :eur 2 :down)
           factor 2]
       (t/is (= (sut/rounded-money-of 3.1 :eur 2 :down) (sut/multiply money factor))))))
@@ -201,7 +212,7 @@
     (let [money (sut/money-of 1 :eur)
           divisor 3]
       (t/is (= (sut/money-of 0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333M :eur) (sut/divide money divisor)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [money (sut/rounded-money-of 1.555 :eur 2 :down)
           divisor 2]
       (t/is (= (sut/rounded-money-of 0.77 :eur 2 :down) (sut/divide money divisor))))))
@@ -211,7 +222,7 @@
     (let [m1 (sut/money-of 1 :eur)
           m2 (sut/money-of -1 :eur)]
       (t/is (= m2 (sut/negate m1)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of -1.555 :eur 2 :down)]
       (t/is (= m2 (sut/negate m1))))))
@@ -222,7 +233,7 @@
           m2 (sut/money-of -1 :eur)]
       (t/is (= m1 (sut/money-abs m1)))
       (t/is (= m1 (sut/money-abs m2)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of -1.555 :eur 2 :down)]
       (t/is (= m1 (sut/money-abs m1)))
@@ -236,7 +247,7 @@
       (t/is (= m2 (sut/money-max m1 m2)))
       (t/is (= m3 (sut/money-max m1 m2 m3)))
       (t/is (thrown? ExceptionInfo (sut/money-max m1 (sut/money-of 1 :gbp))))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of 2.555 :eur 2 :down)
           m3 (sut/rounded-money-of 3.555 :eur 2 :down)
@@ -263,7 +274,7 @@
       (t/is (= m1 (sut/money-min m1 m2)))
       (t/is (= m1 (sut/money-min m1 m2 m3)))
       (t/is (thrown? ExceptionInfo (sut/money-min m1 (sut/money-of 1 :gbp))))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of 2.555 :eur 2 :down)
           m3 (sut/rounded-money-of 3.555 :eur 2 :down)

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -248,7 +248,14 @@
   (t/testing "Rounded Money"
     (let [money (sut/rounded-money-of 1.555 :eur 2 :down)
           divisor 2]
-      (t/is (= (sut/rounded-money-of 0.77 :eur 2 :down) (sut/divide money divisor))))))
+      (t/is (= (sut/rounded-money-of 0.77 :eur 2 :down) (sut/divide money divisor)))))
+  (t/testing "Fast Money"
+    (let [money (sut/fast-money-of 2 :eur)
+          divisor 2]
+      (t/is (= (sut/fast-money-of 1 :eur) (sut/divide money divisor))))
+    (let [money (sut/fast-money-of 1 :eur)
+          divisor 3]
+      (t/is (= (sut/fast-money-of 0.33333 :eur) (sut/divide money divisor))))))
 
 (t/deftest negate
   (t/testing "Money"

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -188,7 +188,18 @@
   (t/testing "Mix money and rounded money"
     (let [m1 (sut/money-of 1 :eur)
           m2 (sut/rounded-money-of 1 :eur)]
-      (t/is (= (sut/money-of 0 :eur) (sut/subtract m1 m2))))))
+      (t/is (= (sut/money-of 0 :eur) (sut/subtract m1 m2)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 3 :eur)
+          m2 (sut/fast-money-of 2 :eur)
+          m3 (sut/fast-money-of 1 :eur)]
+      (t/is (= (sut/fast-money-of 1 :eur) (sut/subtract m1 m2)))
+      (t/is (= (sut/fast-money-of 0 :eur) (sut/subtract m1 m2 m3)))
+      ;; long overflow
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of Long/MIN_VALUE :eur) (sut/fast-money-of 1 :eur))))
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of Long/MAX_VALUE :eur) (sut/fast-money-of -1 :eur))))
+      ;; different currencies
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))))
 
 (t/deftest multiply
   (t/testing "Money"

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -210,12 +210,28 @@
 (t/deftest multiply
   (t/testing "Money"
     (let [money (sut/money-of 1 :eur)
-          factor 2]
-      (t/is (= (sut/money-of 2 :eur) (sut/multiply money factor)))))
+          factor-long 2
+          factor-double 2.5]
+      (t/is (= (sut/money-of 2 :eur) (sut/multiply money factor-long)))
+      (t/is (= (sut/money-of 2.5 :eur) (sut/multiply money factor-double)))))
   (t/testing "Rounded Money"
     (let [money (sut/rounded-money-of 1.555 :eur 2 :down)
-          factor 2]
-      (t/is (= (sut/rounded-money-of 3.1 :eur 2 :down) (sut/multiply money factor))))))
+          factor-long 2
+          factor-double 2.5]
+      (t/is (= (sut/rounded-money-of 3.1 :eur 2 :down) (sut/multiply money factor-long)))
+      (t/is (= (sut/rounded-money-of 3.87 :eur 2 :down) (sut/multiply money factor-double)))))
+  (t/testing "Fast Money"
+    (let [money (sut/fast-money-of 1 :eur)
+          factor-long 2
+          factor-double 2.5]
+      (t/is (= (sut/fast-money-of 2 :eur) (sut/multiply money factor-long)))
+      (t/is (= (sut/fast-money-of 2.5 :eur) (sut/multiply money factor-double))))
+    ;; result cannot be represented as a long
+    (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale
+          min-value (/ Long/MIN_VALUE 100000)] ; 10000 = 10^fast-money-max-scale
+      ;; result cannot be represented as a long
+      (t/is (thrown? ExceptionInfo (sut/multiply (sut/fast-money-of max-value :eur) 2)))
+      (t/is (thrown? ExceptionInfo (sut/multiply (sut/fast-money-of min-value :eur) 2))))))
 
 (t/deftest divide
   (t/testing "Money"

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -82,7 +82,7 @@
       (t/is (thrown? ExceptionInfo (sut/money<= m1 m4)))
       (t/is (thrown? ExceptionInfo (sut/money> m1 m4)))
       (t/is (thrown? ExceptionInfo (sut/money>= m1 m4)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1 :eur)
           m2 (sut/rounded-money-of 1 :eur)
           m3 (sut/rounded-money-of 2 :eur)
@@ -101,15 +101,43 @@
       (t/is (sut/money< m1 m2))
       (t/is (sut/money<= m1 m2))
       (t/is (sut/money> m2 m1))
-      (t/is (sut/money>= m2 m1)))))
+      (t/is (sut/money>= m2 m1))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of 1 :eur)
+          m3 (sut/fast-money-of 2 :eur)
+          m4 (sut/fast-money-of 1 :gbp)]
+      (t/is (sut/money< m1 m3))
+      (t/is (sut/money<= m1 m2))
+      (t/is (sut/money> m3 m1))
+      (t/is (sut/money>= m3 m2))
+      (t/is (thrown? ExceptionInfo (sut/money< m1 m4)))
+      (t/is (thrown? ExceptionInfo (sut/money<= m1 m4)))
+      (t/is (thrown? ExceptionInfo (sut/money> m1 m4)))
+      (t/is (thrown? ExceptionInfo (sut/money>= m1 m4))))))
 
 (t/deftest sign-operations
-  (let [m1 (sut/money-of 0 :eur)
-        m2 (sut/money-of 1 :eur)
-        m3 (sut/money-of -1 :eur)]
-    (t/is (sut/money-zero? m1))
-    (t/is (sut/money-pos? m2))
-    (t/is (sut/money-neg? m3))))
+  (t/testing "Money"
+    (let [m1 (sut/money-of 0 :eur)
+          m2 (sut/money-of 1 :eur)
+          m3 (sut/money-of -1 :eur)]
+      (t/is (sut/money-zero? m1))
+      (t/is (sut/money-pos? m2))
+      (t/is (sut/money-neg? m3))))
+  (t/testing "Rounded Money"
+    (let [m1 (sut/rounded-money-of 0 :eur 2 :down)
+          m2 (sut/rounded-money-of 1 :eur 2 :down)
+          m3 (sut/rounded-money-of -1 :eur 2 :down)]
+      (t/is (sut/money-zero? m1))
+      (t/is (sut/money-pos? m2))
+      (t/is (sut/money-neg? m3))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 0 :eur)
+          m2 (sut/fast-money-of 1 :eur)
+          m3 (sut/fast-money-of -1 :eur)]
+      (t/is (sut/money-zero? m1))
+      (t/is (sut/money-pos? m2))
+      (t/is (sut/money-neg? m3)))))
 
 ;;; Arithmetic operations
 

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -50,6 +50,22 @@
       (t/is (= 1.23M (sut/get-amount m2)))
       (t/is (= 2 (sut/get-scale m2))))))
 
+(t/deftest fast-money-of
+  (t/testing "Different amounts"
+    (let [m1 (sut/fast-money-of 1234 :eur)
+          m2 (sut/fast-money-of 1234.56 :eur)
+          m3 (sut/fast-money-of 1234.5678 :eur)
+          m4 (sut/fast-money-of 0.12345 :btc)]
+      (t/is (= 1234M (sut/get-amount m1)))
+      (t/is (= 1234.56M (sut/get-amount m2)))
+      (t/is (= 1234.5678M (sut/get-amount m3)))
+      (t/is (= 0.12345M (sut/get-amount m4)))
+      ;; scale exceeds the maximum allowed value of 5
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of 0.123456 :btc)))
+      ;; amount cannot be represented as a long
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of (dec (bigdec Long/MIN_VALUE)) :eur)))
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of (inc (bigdec Long/MAX_VALUE)) :eur))))))
+
 ;;; Equality and comparison
 
 (t/deftest comparison

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -265,7 +265,16 @@
   (t/testing "Rounded Money"
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of -1.555 :eur 2 :down)]
-      (t/is (= m2 (sut/negate m1))))))
+      (t/is (= m2 (sut/negate m1)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of -1 :eur)
+          max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale
+          min-value (/ Long/MIN_VALUE 100000) ;10000 = 10^fast-money-max-scale
+          min-value-plus-one (/ (inc Long/MIN_VALUE) 100000)] ; 10000 = 10^fast-money-max-scale
+      (t/is (= m2 (sut/negate m1)))
+      (t/is (= (sut/fast-money-of min-value-plus-one :eur) (sut/negate (sut/fast-money-of max-value :eur))))
+      (t/is (thrown? ExceptionInfo (sut/negate (sut/fast-money-of min-value :eur)))))))
 
 (t/deftest money-abs
   (t/testing "Money"
@@ -277,7 +286,14 @@
     (let [m1 (sut/rounded-money-of 1.555 :eur 2 :down)
           m2 (sut/rounded-money-of -1.555 :eur 2 :down)]
       (t/is (= m1 (sut/money-abs m1)))
-      (t/is (= m1 (sut/money-abs m2))))))
+      (t/is (= m1 (sut/money-abs m2)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of -1 :eur)
+          min-value (/ Long/MIN_VALUE 100000)] ; 10000 = 10^fast-money-max-scale
+      (t/is (= m1 (sut/money-abs m1)))
+      (t/is (= m1 (sut/money-abs m2)))
+      (t/is (thrown? ExceptionInfo (sut/money-abs (sut/fast-money-of min-value :eur)))))))
 
 (t/deftest money-max
   (t/testing "Money"
@@ -304,7 +320,14 @@
       (t/is (= m1 (sut/money-max m1 m2)))
       (t/is (= m1 (sut/money-max m2 m1)))
       (t/is (= (sut/money-of 2 :eur) (sut/money-max m1 m3)))
-      (t/is (= (sut/money-of 2 :eur) (sut/money-max m3 m1))))))
+      (t/is (= (sut/money-of 2 :eur) (sut/money-max m3 m1)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of 2 :eur)
+          m3 (sut/fast-money-of 3 :eur)]
+      (t/is (= m2 (sut/money-max m1 m2)))
+      (t/is (= m3 (sut/money-max m1 m2 m3)))
+      (t/is (thrown? ExceptionInfo (sut/money-max m1 (sut/fast-money-of 1 :gbp)))))))
 
 (t/deftest money-min
   (t/testing "Money"
@@ -331,4 +354,11 @@
       (t/is (= m1 (sut/money-min m1 m2)))
       (t/is (= m1 (sut/money-min m2 m1)))
       (t/is (= (sut/money-of 1 :eur) (sut/money-min m1 m3)))
-      (t/is (= (sut/money-of 1 :eur) (sut/money-min m3 m1))))))
+      (t/is (= (sut/money-of 1 :eur) (sut/money-min m3 m1)))))
+  (t/testing "Fast Money"
+    (let [m1 (sut/fast-money-of 1 :eur)
+          m2 (sut/fast-money-of 2 :eur)
+          m3 (sut/fast-money-of 3 :eur)]
+      (t/is (= m1 (sut/money-min m1 m2)))
+      (t/is (= m1 (sut/money-min m1 m2 m3)))
+      (t/is (thrown? ExceptionInfo (sut/money-min m1 (sut/fast-money-of 1 :gbp)))))))

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -61,10 +61,12 @@
       (t/is (= 1234.5678M (sut/get-amount m3)))
       (t/is (= 0.12345M (sut/get-amount m4)))
       ;; scale exceeds the maximum allowed value of 5
-      (t/is (thrown? ExceptionInfo (sut/fast-money-of 0.123456 :btc)))
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of 0.123456 :btc))))
+    (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale
+          min-value (/ Long/MIN_VALUE 100000)] ; 10000 = 10^fast-money-max-scale
       ;; amount cannot be represented as a long
-      (t/is (thrown? ExceptionInfo (sut/fast-money-of (dec (bigdec Long/MIN_VALUE)) :eur)))
-      (t/is (thrown? ExceptionInfo (sut/fast-money-of (inc (bigdec Long/MAX_VALUE)) :eur))))))
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of (inc max-value) :eur)))
+      (t/is (thrown? ExceptionInfo (sut/fast-money-of (dec min-value) :eur))))))
 
 ;;; Equality and comparison
 
@@ -165,11 +167,13 @@
           m3 (sut/fast-money-of 3 :eur)]
       (t/is (= (sut/fast-money-of 3 :eur) (sut/add m1 m2)))
       (t/is (= (sut/fast-money-of 6 :eur) (sut/add m1 m2 m3)))
-      ;; long overflow
-      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of Long/MAX_VALUE :eur) (sut/fast-money-of 1 :eur))))
-      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of Long/MIN_VALUE :eur) (sut/fast-money-of -1 :eur))))
       ;; different currencies
-      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))))
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))
+    ;; result cannot be represented as a long
+    (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale
+          min-value (/ Long/MIN_VALUE 100000)] ; 10000 = 10^fast-money-max-scale
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of max-value :eur) (sut/fast-money-of 1 :eur))))
+      (t/is (thrown? ExceptionInfo (sut/add (sut/fast-money-of min-value :eur) (sut/fast-money-of -1 :eur)))))))
 
 (t/deftest subtract
   (t/testing "Money"
@@ -195,11 +199,13 @@
           m3 (sut/fast-money-of 1 :eur)]
       (t/is (= (sut/fast-money-of 1 :eur) (sut/subtract m1 m2)))
       (t/is (= (sut/fast-money-of 0 :eur) (sut/subtract m1 m2 m3)))
-      ;; long overflow
-      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of Long/MIN_VALUE :eur) (sut/fast-money-of 1 :eur))))
-      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of Long/MAX_VALUE :eur) (sut/fast-money-of -1 :eur))))
       ;; different currencies
-      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))))
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of 1 :eur) (sut/fast-money-of 1 :gbp)))))
+    ;; result cannot be represented as a long
+    (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale
+          min-value (/ Long/MIN_VALUE 100000)] ; 10000 = 10^fast-money-max-scale
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of min-value :eur) (sut/fast-money-of 1 :eur))))
+      (t/is (thrown? ExceptionInfo (sut/subtract (sut/fast-money-of max-value :eur) (sut/fast-money-of -1 :eur)))))))
 
 (t/deftest multiply
   (t/testing "Money"

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -56,10 +56,10 @@
           m2 (sut/fast-money-of 1234.56 :eur)
           m3 (sut/fast-money-of 1234.5678 :eur)
           m4 (sut/fast-money-of 0.12345 :btc)]
-      (t/is (= 1234M (sut/get-amount m1)))
-      (t/is (= 1234.56M (sut/get-amount m2)))
-      (t/is (= 1234.5678M (sut/get-amount m3)))
-      (t/is (= 0.12345M (sut/get-amount m4)))
+      (t/is (= 1234.0 (sut/get-amount m1)))
+      (t/is (= 1234.56 (sut/get-amount m2)))
+      (t/is (= 1234.5678 (sut/get-amount m3)))
+      (t/is (= 0.12345 (sut/get-amount m4)))
       ;; scale exceeds the maximum allowed value of 5
       (t/is (thrown? ExceptionInfo (sut/fast-money-of 0.123456 :btc))))
     (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale

--- a/test/dinero/core_test.clj
+++ b/test/dinero/core_test.clj
@@ -56,10 +56,10 @@
           m2 (sut/fast-money-of 1234.56 :eur)
           m3 (sut/fast-money-of 1234.5678 :eur)
           m4 (sut/fast-money-of 0.12345 :btc)]
-      (t/is (= 1234.0 (sut/get-amount m1)))
-      (t/is (= 1234.56 (sut/get-amount m2)))
-      (t/is (= 1234.5678 (sut/get-amount m3)))
-      (t/is (= 0.12345 (sut/get-amount m4)))
+      (t/is (= 1234M (sut/get-amount m1)))
+      (t/is (= 1234.56M (sut/get-amount m2)))
+      (t/is (= 1234.5678M (sut/get-amount m3)))
+      (t/is (= 0.12345M (sut/get-amount m4)))
       ;; scale exceeds the maximum allowed value of 5
       (t/is (thrown? ExceptionInfo (sut/fast-money-of 0.123456 :btc))))
     (let [max-value (/ Long/MAX_VALUE 100000) ; 10000 = 10^fast-money-max-scale

--- a/test/dinero/rounding_test.clj
+++ b/test/dinero/rounding_test.clj
@@ -11,18 +11,27 @@
       (t/is (= (core/money-of 1234.56 :eur) (sut/round money 2 :down)))
       (t/is (= (core/money-of 1235 :eur) (sut/round money 0 :up)))
       (t/is (= (core/money-of 1234 :eur) (sut/round money 0 :down)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [money(core/rounded-money-of 1234.5678 :eur)]
       (t/is (= (core/rounded-money-of 1234.57 :eur) (sut/round money)))
       (t/is (= (core/rounded-money-of 1234.57 :eur 2 :up) (sut/round money 2 :up)))
       (t/is (= (core/rounded-money-of 1234.57 :eur 2 :down) (sut/round money 2 :down)))
       (t/is (= (core/rounded-money-of 1235 :eur 0 :up) (sut/round money 0 :up)))
       (t/is (= (core/rounded-money-of 1234 :eur 0 :down) (sut/round money 0 :down)))))
+  (t/testing "Fast Money"
+    (let[money (core/fast-money-of 1234.5678 :eur)]
+      (t/is (= (core/fast-money-of 1234.57 :eur) (sut/round money)))
+      (t/is (= (core/fast-money-of 1234.57 :eur) (sut/round money 2 :up)))
+      (t/is (= (core/fast-money-of 1234.56 :eur) (sut/round money 2 :down)))
+      (t/is (= (core/fast-money-of 1235 :eur) (sut/round money 0 :up)))
+      (t/is (= (core/fast-money-of 1234 :eur) (sut/round money 0 :down)))))
   (t/testing "Currency with no minor units (`nil`)"
     (let [money (core/money-of 1.23 :xau)
-          rounded-money (core/rounded-money-of 1.23 :xau)]
+          rounded-money (core/rounded-money-of 1.23 :xau)
+          fast-money (core/fast-money-of 1.23 :xau)]
       (t/is (= 1.23M (core/get-amount (sut/round money))))
-      (t/is (= 1.23M (core/get-amount (sut/round rounded-money)))))))
+      (t/is (= 1.23M (core/get-amount (sut/round rounded-money))))
+      (t/is (= 1.23 (core/get-amount (sut/round fast-money)))))))
 
 (t/deftest round-chf
   (t/testing "Money"
@@ -38,7 +47,7 @@
       (t/is (= (core/money-of 1.05 :chf) (sut/round m4 sut/chf-rounding-fn)))
       (t/is (= (core/money-of 1.10 :chf) (sut/round m5 sut/chf-rounding-fn)))
       (t/is (= (core/money-of 1.10 :chf) (sut/round m6 sut/chf-rounding-fn)))))
-  (t/testing "Rounded money"
+  (t/testing "Rounded Money"
     (let [m1 (core/rounded-money-of 0.975 :chf)
           m2 (core/rounded-money-of 1.024 :chf)
           m3 (core/rounded-money-of 1.025 :chf)
@@ -50,4 +59,18 @@
       (t/is (= (core/rounded-money-of 1 :chf 2 :half-up) (sut/round m3 sut/chf-rounding-fn)))
       (t/is (= (core/rounded-money-of 1.05 :chf 2 :half-up) (sut/round m4 sut/chf-rounding-fn)))
       (t/is (= (core/rounded-money-of 1.10 :chf 2 :half-up) (sut/round m5 sut/chf-rounding-fn)))
-      (t/is (= (core/rounded-money-of 1.10 :chf 2 :half-up) (sut/round m6 sut/chf-rounding-fn))))))
+      (t/is (= (core/rounded-money-of 1.10 :chf 2 :half-up) (sut/round m6 sut/chf-rounding-fn)))))
+  (t/testing
+      "Fast Money"
+    (let [m1 (core/fast-money-of 0.975 :chf)
+          m2 (core/fast-money-of 1.024 :chf)
+          m3 (core/fast-money-of 1.025 :chf)
+          m4 (core/fast-money-of 1.074 :chf)
+          m5 (core/fast-money-of 1.075 :chf)
+          m6 (core/fast-money-of 1.124 :chf)]
+      (t/is (= (core/fast-money-of 1 :chf) (sut/round m1 sut/chf-rounding-fn)))
+      (t/is (= (core/fast-money-of 1 :chf) (sut/round m2 sut/chf-rounding-fn)))
+      (t/is (= (core/fast-money-of 1.05 :chf) (sut/round m3 sut/chf-rounding-fn)))
+      (t/is (= (core/fast-money-of 1.05 :chf) (sut/round m4 sut/chf-rounding-fn)))
+      (t/is (= (core/fast-money-of 1.10 :chf) (sut/round m5 sut/chf-rounding-fn)))
+      (t/is (= (core/fast-money-of 1.10 :chf) (sut/round m6 sut/chf-rounding-fn))))))

--- a/test/dinero/rounding_test.clj
+++ b/test/dinero/rounding_test.clj
@@ -31,7 +31,7 @@
           fast-money (core/fast-money-of 1.23 :xau)]
       (t/is (= 1.23M (core/get-amount (sut/round money))))
       (t/is (= 1.23M (core/get-amount (sut/round rounded-money))))
-      (t/is (= 1.23 (core/get-amount (sut/round fast-money)))))))
+      (t/is (= 1.23M (core/get-amount (sut/round fast-money)))))))
 
 (t/deftest round-chf
   (t/testing "Money"


### PR DESCRIPTION
This PR introduces a `FastMoney` data type, inspired by JavaMoney's [FastMoney](https://github.com/JavaMoney/jsr354-ri/blob/master/moneta-core/src/main/java/org/javamoney/moneta/FastMoney.java).

Unlike `Money`, which uses `BigDecimal` for precision, `FastMoney` represents amounts using `long`, aiming to improve performance at the cost of some precision.